### PR TITLE
Use type-equality shim, drop pre GHC-7 support

### DIFF
--- a/eq.cabal
+++ b/eq.cabal
@@ -57,6 +57,9 @@ library
   if impl(ghc >= 8.2)
     exposed-modules: Data.Eq.Type.Hetero
 
+  if !impl(ghc >= 7.8)
+     build-depends: type-equality >=1 && <2
+
   ghc-options: -Wall
   default-language: Haskell2010
   hs-source-dirs: src

--- a/eq.cabal
+++ b/eq.cabal
@@ -44,15 +44,15 @@ library
     TypeOperators
 
   build-depends:
-    base          == 4.*,
+    base          >= 4.3 && <5,
     semigroupoids >= 4 && < 6
 
   exposed-modules:
     Data.Eq.Type
 
-  if impl(ghc >= 7.0)
-    default-extensions: TypeFamilies
-    cpp-options: -DLANGUAGE_TypeFamilies
+  -- We always have TypeFamilies, we don't support pre GHC-7 compilers.
+  -- TypeFamilies are needed to implement lower combinators.
+  default-extensions: TypeFamilies
 
   if impl(ghc >= 8.2)
     exposed-modules: Data.Eq.Type.Hetero

--- a/src/Data/Eq/Type.hs
+++ b/src/Data/Eq/Type.hs
@@ -7,9 +7,9 @@
 {-# LANGUAGE RoleAnnotations #-}
 #endif
 #if defined(__GLASGOW_HASKELL__) && MIN_VERSION_base(4,7,0)
-#define HAS_DATA_TYPE_EQUALITY 1
-{-# LANGUAGE GADTs #-}
+#define HAS_DATA_TYPE_COERCION 1
 #endif
+{-# LANGUAGE GADTs #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -46,12 +46,12 @@ module Data.Eq.Type
   , lower2
   , lower3
 #endif
-#ifdef HAS_DATA_TYPE_EQUALITY
   -- * 'Eq.:~:' equivalence
   -- | "Data.Type.Equality" GADT definition is equivalent in power
   , fromLeibniz
   , toLeibniz
 
+#ifdef HAS_DATA_TYPE_COERCION
   -- * 'Co.Coercion' conversion
   -- | Leibnizian equality can be converted to representational equality
   , reprLeibniz
@@ -63,10 +63,10 @@ import Control.Category
 import Data.Semigroupoid
 import Data.Groupoid
 
-#ifdef HAS_DATA_TYPE_EQUALITY
+#ifdef HAS_DATA_TYPE_COERCION
 import qualified Data.Type.Coercion as Co
-import qualified Data.Type.Equality as Eq
 #endif
+import qualified Data.Type.Equality as Eq
 
 infixl 4 :=
 
@@ -184,7 +184,6 @@ lower3 :: forall a b f g c c' d d'. f a c d := g b c' d' -> a := b
 lower3 eq = unlower3 (subst eq (Lower3 refl :: Lower3 f g a (f a c d)))
 #endif
 
-#ifdef HAS_DATA_TYPE_EQUALITY
 fromLeibniz :: a := b -> a Eq.:~: b
 fromLeibniz a = subst a Eq.Refl
 
@@ -194,6 +193,7 @@ toLeibniz Eq.Refl = refl
 instance Eq.TestEquality ((:=) a) where
   testEquality fa fb = Just (fromLeibniz (trans (symm fa) fb))
 
+#ifdef HAS_DATA_TYPE_COERCION
 reprLeibniz :: a := b -> Co.Coercion a b
 reprLeibniz a = subst a Co.Coercion
 

--- a/src/Data/Eq/Type.hs
+++ b/src/Data/Eq/Type.hs
@@ -40,12 +40,10 @@ module Data.Eq.Type
   , lift
   , lift2, lift2'
   , lift3, lift3'
-#ifdef LANGUAGE_TypeFamilies
   -- * Lowering equality
   , lower
   , lower2
   , lower3
-#endif
   -- * 'Eq.:~:' equivalence
   -- | "Data.Type.Equality" GADT definition is equivalent in power
   , fromLeibniz
@@ -126,8 +124,7 @@ lift3 a = unlift3 (subst a (Lift3 refl))
 lift3' :: a := b -> c := d -> e := f -> g a c e := g b d f
 lift3' ab cd ef = lift3 ab `subst` lift2 cd `subst` lift ef
 
-#ifdef LANGUAGE_TypeFamilies
-# ifdef LANGUAGE_PolyKinds
+#ifdef LANGUAGE_PolyKinds
 -- This is all more complicated than it needs to be. Ideally, we would just
 -- write:
 --
@@ -151,11 +148,11 @@ lift3' ab cd ef = lift3 ab `subst` lift2 cd `subst` lift ef
 type family GenInj  (f :: j -> k)           (g :: j -> k)             (x :: k) :: j
 type family GenInj2 (f :: i -> j -> k)      (g :: i -> j' -> k)       (x :: k) :: i
 type family GenInj3 (f :: h -> i -> j -> k) (g :: h -> i' -> j' -> k) (x :: k) :: h
-# else
+#else
 type family GenInj  (f :: * -> *)           (g :: * -> *)           (x :: *) :: *
 type family GenInj2 (f :: * -> * -> *)      (g :: * -> * -> *)      (x :: *) :: *
 type family GenInj3 (f :: * -> * -> * -> *) (g :: * -> * -> * -> *) (x :: *) :: *
-# endif
+#endif
 
 type instance GenInj  f g (f a) = a
 type instance GenInj  f g (g b) = b
@@ -182,7 +179,6 @@ lower2 eq = unlower2 (subst eq (Lower2 refl :: Lower2 f g a (f a c)))
 -- | ... these definitions are poly-kinded on GHC 7.6 and up.
 lower3 :: forall a b f g c c' d d'. f a c d := g b c' d' -> a := b
 lower3 eq = unlower3 (subst eq (Lower3 refl :: Lower3 f g a (f a c d)))
-#endif
 
 fromLeibniz :: a := b -> a Eq.:~: b
 fromLeibniz a = subst a Eq.Refl


### PR DESCRIPTION
I tried to make Hetero module work with GHC-8.0 too,
but it wasn't as easy as just adding the import,
so I didn't do it.

I didn't add changelog entries to not conflict with my other PR.